### PR TITLE
Prevent encoding errors while reading README description on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup, find_packages
 import shutil
 import os
 import filecmp
+import codecs
 
 PACKAGE = 'sru'
 
@@ -10,7 +11,7 @@ PACKAGE = 'sru'
 def readme():
     """ Return the README text.
     """
-    with open('README.md') as fh:
+    with codecs.open('README.md', encoding='utf-8') as fh:
         return fh.read()
 
 ################################################################################


### PR DESCRIPTION
Sometimes the installation process will fail on enviroments where the locale is ill-defined.