### PR TITLE
add -O2 flag to cpu kernel compilation

### DIFF
--- a/sru/sru_functional.py
+++ b/sru/sru_functional.py
@@ -17,7 +17,11 @@ def _lazy_load_cpu_kernel():
     try:
         from torch.utils.cpp_extension import load
         cpu_source = os.path.join(os.path.dirname(__file__), "sru_cpu_impl.cpp")
-        SRU_CPU_kernel = load(name="sru_cpu_impl", sources=[cpu_source])
+        SRU_CPU_kernel = load(
+            name="sru_cpu_impl",
+            sources=[cpu_source],
+            extra_cflags=['-O2'],
+        )
     except:
         # use Python version instead
         SRU_CPU_kernel = False


### PR DESCRIPTION
By default, the torch `load` utility function adds only the flags -fPIC
-std=c++11. This change adds an optimization flag to cpu kernel loading.

In the comparison function, this improved the cpu runtime from 0.98
seconds to 0.54 (average of 5 runs).

Test plan: run comparison script